### PR TITLE
WIP add gitpush CRD

### DIFF
--- a/deploy/crds/devconsole_v1alpha1_gitpush_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitpush_crd.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: gitpushes.devconsole.openshift.io
+spec:
+  group: devconsole.openshift.io
+  names:
+    kind: GitPush
+    listKind: GitPushList
+    plural: gitpushes
+    singular: gitpush
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
This PR adds the git-push custom resource, used to represent a git push operation.  

**TO DISCUSS** - there remains a question of naming.. should we be using `devconsole.openshift.io`, or `devopsconsole.openshift.io`?  The impression from mailing list discussions are that we are going with "Developer Console", making `devconsole.openshift.io` the more likely package naming.