### PR TITLE
fixing label issue

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -87,7 +87,7 @@ ALL_PKGS_EXCLUDE_PATTERN = 'vendor\|app\|tool\/cli\|design\|client\|test'
 # This pattern excludes some folders from the go code analysis
 GOANALYSIS_PKGS_EXCLUDE_PATTERN="vendor|app|client|tool/cli"
 GOANALYSIS_DIRS=$(shell go list -f {{.Dir}} ./... | grep -v -E $(GOANALYSIS_PKGS_EXCLUDE_PATTERN))
-RANDOM := $(shell uuidgen)
+RANDOM := $(shell bash -c 'echo $$RANDOM')
 
 export TEST_NAMESPACE='devconsole-e2e-test-$(RANDOM)'
 export TEST_NAMESPACE_TEMP := ''


### PR DESCRIPTION
fixing the following error: 

`The ProjectRequest "devconsole-e2e-test-8DF25498-419D-47F3-843C-6BBB5EEE1DB2" is invalid: metadata.name: Invalid value: "devconsole-e2e-test-8DF25498-419D-47F3-843C-6BBB5EEE1DB2": a DNS-1123 label must consist of lowercase`