### PR TITLE
Extend existing E2E test to cover all elements in component

### DIFF
--- a/test/e2e/component_operator_test.go
+++ b/test/e2e/component_operator_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+
+	"github.com/redhat-developer/devopsconsole-operator/pkg/apis"
+	componentsv1alpha1 "github.com/redhat-developer/devopsconsole-operator/pkg/apis/devopsconsole/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 60
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
+)
+
+type ComponentTestSuite struct {
+	suite.Suite
+	namespace string
+	framework *framework.Framework
+	client    *corev1client.CoreV1Client
+	ctx       *framework.TestCtx
+}
+
+func (suite *ComponentTestSuite) SetupSuite() {
+	suite.framework = framework.Global
+
+	coreclient, err := corev1client.NewForConfig(framework.Global.KubeConfig)
+	require.NoError(suite.T(), err, "failed to create new client")
+	suite.client = coreclient
+
+	suite.ctx = framework.NewTestCtx(suite.T())
+
+	namespace, err := suite.ctx.GetNamespace()
+	require.NoError(suite.T(), err, "failed to get namespace where operator needs to run")
+	suite.namespace = namespace
+	suite.T().Log(fmt.Sprintf("namespace: %s", suite.namespace))
+
+	// Register types with framework scheme
+	componentList := &componentsv1alpha1.ComponentList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Component",
+			APIVersion: "devopsconsole.openshift.io/v1alpha1",
+		},
+	}
+	err = framework.AddToFrameworkScheme(apis.AddToScheme, componentList)
+	if err != nil {
+		suite.T().Fatalf("failed to add custom resource scheme to framework: %v", err)
+	}
+
+	err = suite.ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: suite.ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(suite.T(), err, "failed to initialize cluster resources")
+	suite.T().Log("Initialized cluster resources")
+
+	// wait for component-operator to be ready
+	err = e2eutil.WaitForDeployment(suite.T(), suite.framework.KubeClient, suite.namespace, "devopsconsole-operator", 1, retryInterval, timeout)
+	require.NoError(suite.T(), err, "failed while waiting for operator deployment")
+
+	suite.T().Log("component-operator is ready and running state")
+}
+
+// ComponentTest does e2e test as per operator-sdk documentation
+// https://github.com/operator-framework/operator-sdk/blob/cc7b175/doc/test-framework/writing-e2e-tests.md
+func (suite *ComponentTestSuite) TestComponent() {
+
+	suite.T().Log(fmt.Sprintf("namespace: %s", suite.namespace))
+	// create a Component custom resource
+	cr := &componentsv1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Component",
+			APIVersion: "devopsconsole.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycomp",
+			Namespace: suite.namespace,
+		},
+		Spec: componentsv1alpha1.ComponentSpec{
+			BuildType: "nodejs",
+			Codebase:  "https://github.com/nodeshift-starters/nodejs-rest-http-crud",
+		},
+	}
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	err := suite.framework.Client.Create(context.TODO(), cr, &framework.CleanupOptions{TestContext: suite.ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	require.NoError(suite.T(), err, "failed to create custom resource of kind `Component`")
+
+	suite.T().Run("retrieve component and verify related resources are created", func(t *testing.T) {
+		err = suite.framework.Client.Get(context.TODO(), types.NamespacedName{Name: "mycomp", Namespace: suite.namespace}, cr)
+		require.NoError(t, err, "failed to retrieve custom resource of kind `Component`")
+		require.Equal(t, "https://github.com/nodeshift-starters/nodejs-rest-http-crud", cr.Spec.Codebase)
+		require.Equal(t, "nodejs", cr.Spec.BuildType)
+
+		require.Equal(t, "mycomp", cr.ObjectMeta.Name)
+		require.Equal(t, suite.namespace, cr.ObjectMeta.Namespace)
+
+		// The following (2) statements will fail due to
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/202
+		// This issue is resolved in controller-runtime 0.1.8
+		require.Equal(t, "Component", cr.TypeMeta.Kind)
+		require.Equal(t, "devopsconsole.openshift.io/v1alpha1", cr.TypeMeta.APIVersion)
+	})
+}
+
+func (suite *ComponentTestSuite) TearDownSuite() {
+	err := suite.client.Namespaces().Delete(suite.namespace, &metav1.DeleteOptions{})
+	require.NoError(suite.T(), err, "failed to delete namespace")
+
+	os.Unsetenv("TEST_NAMESPACE")
+	suite.ctx.Cleanup()
+
+	suite.T().Log("teardown complete")
+}
+
+func TestComponentTestSuite(t *testing.T) {
+	suite.Run(t, new(ComponentTestSuite))
+}


### PR DESCRIPTION
Small extension to basic operator E2E test to query/verify Kind + ApiVersion.

The new tests fail at present due to a known bug in the controller-runtime:
https://github.com/kubernetes-sigs/controller-runtime/issues/202

I'd be in favor of merging this test and observing it fail until we update to the library version (0.1.8) that fixes this bug - https://github.com/kubernetes-sigs/controller-runtime/issues/231

Gopkg.toml
[[override]]
  name = "sigs.k8s.io/controller-runtime"
  version = "=v0.1.4"

