### PR TITLE
Add git committer info to image/container

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -5,6 +5,9 @@ ENV LANG=en_US.utf8
 ENV GOPATH /tmp/go
 ARG GO_PACKAGE_PATH=github.com/redhat-developer/devopsconsole-operator
 
+ENV GIT_COMMITTER_NAME devtools
+ENV GIT_COMMITTER_EMAIL devtools@redhat.com
+
 RUN yum install epel-release -y \
     && yum install --enablerepo=centosplus install -y --quiet \
     findutils \


### PR DESCRIPTION
To workaround https://github.com/jenkinsci/docker/issues/519 since the installed git version is  x86_64 1.8.3.1-20.el7   , in which the git-clone fails if uuid is absent in the the `/etc/passwd` 

Error initially noticed in https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/3262/rehearse-3262-pull-ci-redhat-developer-devconsole-operator-master-build/5/build-log.txt