### PR TITLE
Add list/watch for BuildConfig and DeploymentConfig

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -44,6 +44,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - apps.openshift.io
   resources:
@@ -51,3 +53,6 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+

--- a/manifests/devconsole/0.1.0/devconsole-operator.v0.1.0.clusterserviceversion.yaml
+++ b/manifests/devconsole/0.1.0/devconsole-operator.v0.1.0.clusterserviceversion.yaml
@@ -124,6 +124,8 @@ spec:
           verbs:
           - create
           - get
+          - list
+          - watch
         - apiGroups:
           - apps.openshift.io
           resources:
@@ -131,6 +133,8 @@ spec:
           verbs:
           - create
           - get
+          - list
+          - watch
         serviceAccountName: devconsole-operator
     strategy: deployment
   installModes:


### PR DESCRIPTION
follow-up on https://github.com/redhat-developer/devconsole-operator/pull/44
Add the 2 missing roles to avoid:
```
1) E0401 08:07:55.507381       1 reflector.go:322] github.com/redhat-developer/devopsconsole-operator/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:196: Failed to watch *v1.BuildConfig: unknown (get buildconfigs.build.openshift.io)

2)E0401 08:07:55.875291       1 reflector.go:205] github.com/redhat-developer/devopsconsole-operator/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:196: Failed to list *v1.DeploymentConfig: deploymentconfigs.apps.openshift.io is forbidden: User "system:serviceaccount:devopsconsole:devopsconsole-operator" cannot list deploymentconfigs.apps.openshift.io at the cluster scope: no RBAC policy matched
```