### PR TITLE
use the correct namespace depending on target

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -5,6 +5,7 @@ UNAME_S := $(shell uname -s)
 include ./make/verbose.mk
 include ./make/out.mk
 
+export DEPLOY_NAMESAPCE=
 .PHONY: test
 ## Runs Go package tests and stops when the first one fails
 test: ./vendor
@@ -60,6 +61,7 @@ e2e-cleanup: get-test-namespace
 .PHONY: test-olm-integration
 ## Runs the OLM integration tests without coverage
 test-olm-integration: push-operator-image olm-integration-setup
+	$(eval DEPLOYED_NAMESAPCE := operators)
 	$(call log-info,"Running OLM integration test: $@")
 	$(Q)oc apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
 	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
@@ -95,6 +97,7 @@ build-image-local: e2e-setup
 
 .PHONY: e2e-local
 e2e-local: build-image-local
+	$(eval DEPLOYED_NAMESAPCE := $(TEST_NAMESPACE))
 	$(Q)-oc login -u system:admin
 	$(Q)-oc project $(TEST_NAMESPACE)
 	$(Q)-oc create -f ./deploy/crds/devconsole_v1alpha1_component_crd.yaml

--- a/make/test.mk
+++ b/make/test.mk
@@ -5,7 +5,8 @@ UNAME_S := $(shell uname -s)
 include ./make/verbose.mk
 include ./make/out.mk
 
-export DEPLOY_NAMESAPCE=
+export DEPLOYED_NAMESAPCE:=
+
 .PHONY: test
 ## Runs Go package tests and stops when the first one fails
 test: ./vendor

--- a/test/e2e/component_test.go
+++ b/test/e2e/component_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -53,8 +54,12 @@ func TestComponent(t *testing.T) {
 	// get global framework variables
 	f := framework.Global
 	t.Log(fmt.Sprintf("namespace: %s", namespace))
+
+	// get the namespace to check deployment on
+	deployedNamespace := os.Getenv("DEPLOY_NAMESAPCE")
+
 	// wait for component-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, "operators", "devconsole-operator", 1, retryInterval, timeout*2)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, deployedNamespace, "devconsole-operator", 1, retryInterval, timeout*2)
 	require.NoError(t, err, "failed while waiting for operator deployment")
 
 	t.Log("component is ready and running")

--- a/test/e2e/component_test.go
+++ b/test/e2e/component_test.go
@@ -55,11 +55,8 @@ func TestComponent(t *testing.T) {
 	f := framework.Global
 	t.Log(fmt.Sprintf("namespace: %s", namespace))
 
-	// get the namespace to check deployment on
-	deployedNamespace := os.Getenv("DEPLOYED_NAMESAPCE")
-
 	// wait for component-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, deployedNamespace, "devconsole-operator", 1, retryInterval, timeout*2)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, os.Getenv("DEPLOYED_NAMESAPCE"), "devconsole-operator", 1, retryInterval, timeout*2)
 	require.NoError(t, err, "failed while waiting for operator deployment")
 
 	t.Log("component is ready and running")

--- a/test/e2e/component_test.go
+++ b/test/e2e/component_test.go
@@ -56,7 +56,7 @@ func TestComponent(t *testing.T) {
 	t.Log(fmt.Sprintf("namespace: %s", namespace))
 
 	// get the namespace to check deployment on
-	deployedNamespace := os.Getenv("DEPLOY_NAMESAPCE")
+	deployedNamespace := os.Getenv("DEPLOYED_NAMESAPCE")
 
 	// wait for component-operator to be ready
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, deployedNamespace, "devconsole-operator", 1, retryInterval, timeout*2)


### PR DESCRIPTION
Currently the component_test waits for deployment on the "operators" namespace. 

This namespace is only created via the` make test-olm-integration`

However, when running the `make e2e-local target`, "operators" namespace is never created and hence the test will fail. 

This change sets the deployed_namespace var which can be used in the component_test in the waitForDeployment call. 