### PR TITLE
Proper Cleanup for test-olm-integration to pass

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -75,8 +75,9 @@ test-olm-integration: push-operator-image olm-integration-setup
 	$(Q)sed -e "s,REPLACE_IMAGE,$(DEVCONSOLE_OPERATOR_REGISTRY_IMAGE):$(devconsole_version)-$(TAG)," ./test/e2e/catalog_source.yaml | oc apply -f -
 	$(Q)oc apply -f ./test/e2e/subscription.yaml
 
-	@-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
-	@-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
+	# The following cleanup is required due to a potential bug in the test framework.
+	$(Q)-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
+	$(Q)-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
 	$(Q)operator-sdk test local ./test/e2e/ --go-test-flags "-v -parallel=1"
 
 .PHONY: olm-integration-setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -75,9 +75,6 @@ test-olm-integration: push-operator-image olm-integration-setup
 	$(Q)sed -e "s,REPLACE_IMAGE,$(DEVCONSOLE_OPERATOR_REGISTRY_IMAGE):$(devconsole_version)-$(TAG)," ./test/e2e/catalog_source.yaml | oc apply -f -
 	$(Q)oc apply -f ./test/e2e/subscription.yaml
 
-	# The following cleanup is required due to a potential bug in the test framework.
-	$(Q)-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
-	$(Q)-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
 	$(Q)operator-sdk test local ./test/e2e/ --go-test-flags "-v -parallel=1"
 
 .PHONY: olm-integration-setup
@@ -89,6 +86,9 @@ olm-integration-cleanup: get-test-namespace
 	$(Q)oc login -u system:admin
 	$(Q)-oc delete subscription my-devconsole -n operators
 	$(Q)-oc delete catalogsource my-catalog -n olm
+	# The following cleanup is required due to a potential bug in the test framework.
+	$(Q)-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
+	$(Q)-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
 	$(Q)-oc delete project $(TEST_NAMESPACE)  --wait
 
 #-------------------------------------------------------------------------------

--- a/make/test.mk
+++ b/make/test.mk
@@ -75,6 +75,8 @@ test-olm-integration: push-operator-image olm-integration-setup
 	$(Q)sed -e "s,REPLACE_IMAGE,$(DEVCONSOLE_OPERATOR_REGISTRY_IMAGE):$(devconsole_version)-$(TAG)," ./test/e2e/catalog_source.yaml | oc apply -f -
 	$(Q)oc apply -f ./test/e2e/subscription.yaml
 
+	@-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
+	@-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
 	$(Q)operator-sdk test local ./test/e2e/ --go-test-flags "-v -parallel=1"
 
 .PHONY: olm-integration-setup


### PR DESCRIPTION
The makefile target test-olm-integration was failing due to the improper/partial cleanup of some resources by the e2e test framework. This fixes the test by cleaning up ClusterRole and ClusterRoleBinding.

https://github.com/operator-framework/operator-sdk/issues/1287