### PR TITLE
Ensure dependencies are built

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -36,7 +36,7 @@ create-cr:
 
 .PHONY: build-operator-image
 ## Build and create the operator container image
-build-operator-image:
+build-operator-image: ./vendor
 	operator-sdk build $(DEVCONSOLE_OPERATOR_IMAGE):$(TAG)
 
 .PHONY: push-operator-image


### PR DESCRIPTION
Run `dep ensure` through `./vendor` target