### PR TITLE
Remove cluster role & role binding cleanup

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -111,9 +111,6 @@ ifeq ($(OPENSHIFT_VERSION),4)
 	$(Q)-oc delete subscription my-devconsole -n openshift-operators
 	$(Q)-oc delete catalogsource my-catalog -n openshift-operator-lifecycle-manager
 endif
-	# The following cleanup is required due to a potential bug in the test framework.
-	$(Q)-oc delete clusterroles.rbac.authorization.k8s.io "devconsole-operator"
-	$(Q)-oc delete clusterrolebindings.rbac.authorization.k8s.io "devconsole-operator"
 	$(Q)-oc delete project $(TEST_NAMESPACE)  --wait
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
It was a workaround as the operator was using older version of SDK.
Refer PR #96