### PR TITLE
Move operator courier under lint

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
@@ -16,6 +15,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	devconsoleapi "github.com/redhat-developer/devconsole-api/pkg/apis"
 	"github.com/redhat-developer/devconsole-operator/pkg/apis"
 	"github.com/redhat-developer/devconsole-operator/pkg/controller"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -23,18 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	devconsoleapi "github.com/redhat-developer/devconsole-api/pkg/apis"
-)
-
-var (
-	// Commit current build commit set by build script
-	Commit = "0"
-	// BuildTime set by build script in ISO 8601 (UTC) format:
-	// YYYY-MM-DDThh:mm:ssTZD (see https://www.w3.org/TR/NOTE-datetime for
-	// details)
-	BuildTime = "0"
-	// StartTime in ISO 8601 (UTC) format
-	StartTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 )
 
 var log = logf.Log.WithName("cmd")

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -6,7 +6,7 @@ include ./make/go.mk
 
 .PHONY: lint
 ## Runs linters on Go code files and YAML files
-lint: lint-go-code lint-yaml
+lint: lint-go-code lint-yaml courier
 
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" | grep -v vendor)
 .PHONY: lint-yaml
@@ -17,8 +17,23 @@ lint-yaml: ${YAML_FILES}
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
 lint-go-code:
-	$(Q)go get github.com/golangci/golangci-lint/cmd/golangci-lint
+	# binary will be $(go env GOPATH)/bin/golangci-lint
+	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.16.0
 	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run
+
+.PHONY: courier
+## Validate manifests using operator-courier
+courier:
+	$(Q)python3 -m venv ./out/venv3
+	$(Q)./out/venv3/bin/pip install --upgrade setuptools
+	$(Q)./out/venv3/bin/pip install --upgrade pip
+	$(Q)./out/venv3/bin/pip install operator-courier==1.3.0
+	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
+	$(eval devconsole_version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
+	$(Q)cp ./deploy/crds/*.yaml ./manifests/devconsole/$(devconsole_version)/
+	# flatten command is throwing error. suppress it for now
+	@-./out/venv3/bin/operator-courier flatten ./manifests/devconsole ./out/manifests-flat
+	$(Q)./out/venv3/bin/operator-courier verify ./out/manifests-flat
 
 endif
 

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -19,7 +19,7 @@ lint-yaml: ${YAML_FILES}
 lint-go-code:
 	# binary will be $(go env GOPATH)/bin/golangci-lint
 	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.16.0
-	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run
+	$(Q)$(shell go env GOPATH)/bin/golangci-lint ${V_FLAG} run
 
 .PHONY: courier
 ## Validate manifests using operator-courier

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -1,6 +1,8 @@
 ifndef LINT_MK
 LINT_MK:=# Prevent repeated "-include".
 
+GOLANGCI_LINT_BIN=./out/golangci-lint
+
 include ./make/verbose.mk
 include ./make/go.mk
 
@@ -16,10 +18,11 @@ lint-yaml: ${YAML_FILES}
 
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
-lint-go-code:
-	# binary will be $(go env GOPATH)/bin/golangci-lint
-	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.16.0
-	$(Q)$(shell go env GOPATH)/bin/golangci-lint ${V_FLAG} run
+lint-go-code: $(GOLANGCI_LINT_BIN)
+	$(Q)./out/golangci-lint ${V_FLAG} run
+
+$(GOLANGCI_LINT_BIN):
+	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.16.0
 
 .PHONY: courier
 ## Validate manifests using operator-courier

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -13,12 +13,12 @@ lint: lint-go-code lint-yaml courier
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" | grep -v vendor)
 .PHONY: lint-yaml
 ## runs yamllint on all yaml files
-lint-yaml: ${YAML_FILES}
+lint-yaml: ./vendor ${YAML_FILES}
 	$(Q)yamllint -c .yamllint $^
 
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
-lint-go-code: $(GOLANGCI_LINT_BIN)
+lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
 	$(Q)./out/golangci-lint ${V_FLAG} run
 
 $(GOLANGCI_LINT_BIN):

--- a/make/test.mk
+++ b/make/test.mk
@@ -9,22 +9,8 @@ export DEPLOYED_NAMESPACE:=
 
 .PHONY: test
 ## Runs Go package tests and stops when the first one fails
-test: ./vendor courier
+test: ./vendor
 	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -failfast
-
-.PHONY: courier
-## Validate manifests using operator-courier
-courier:
-	$(Q)python3 -m venv ./out/venv3
-	$(Q)./out/venv3/bin/pip install --upgrade setuptools
-	$(Q)./out/venv3/bin/pip install --upgrade pip
-	$(Q)./out/venv3/bin/pip install operator-courier==1.3.0
-	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
-	$(eval devconsole_version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
-	$(Q)cp ./deploy/crds/*.yaml ./manifests/devconsole/$(devconsole_version)/
-	# flatten command is throwing error. suppress it for now
-	@-./out/venv3/bin/operator-courier flatten ./manifests/devconsole ./out/manifests-flat
-	$(Q)./out/venv3/bin/operator-courier verify ./out/manifests-flat
 
 .PHONY: test-coverage
 ## Runs Go package tests and produces coverage information

--- a/make/test.mk
+++ b/make/test.mk
@@ -9,7 +9,7 @@ export DEPLOYED_NAMESPACE:=
 
 .PHONY: test
 ## Runs Go package tests and stops when the first one fails
-test: ./vendor
+test: ./vendor courier
 	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -failfast
 
 .PHONY: test-coverage

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -152,7 +152,7 @@ func (r *ReconcileComponent) Reconcile(request reconcile.Request) (reconcile.Res
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		if instance.Spec.Exposed == true {
+		if instance.Spec.Exposed {
 			_, err = r.CreateRoute(instance)
 			if err != nil {
 				return reconcile.Result{}, err


### PR DESCRIPTION
* Change installation of GolangCI-lint tool to use the recommended way.
* This required to run it through CI:
https://jira.coreos.com/browse/ODC-506
* Fix the lint issues produced by `make lint`