### PR TITLE
Set `GOCACHE` environment variable explicitly

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -19,7 +19,9 @@ lint-yaml: ./vendor ${YAML_FILES}
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
 lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
-	$(Q)./out/golangci-lint ${V_FLAG} run
+	# This is required for OpenShift CI enviroment
+	# Ref: https://github.com/openshift/release/pull/3438#issuecomment-482053250
+	$(Q)GOCACHE=$(shell pwd)/out/gocache ./out/golangci-lint ${V_FLAG} run
 
 $(GOLANGCI_LINT_BIN):
 	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.16.0


### PR DESCRIPTION
This is required for OpenShift CI enviroment
Ref:
https://github.com/openshift/release/pull/3438#issuecomment-482053250