### PR TITLE
Use `KUBECONFIG` instead of username & password

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -12,8 +12,6 @@ DEVCONSOLE_OPERATOR_IMAGE?=quay.io/redhat-developers/devconsole-operator
 TIMESTAMP:=$(shell date +%s)
 TAG?=$(GIT_COMMIT_ID_SHORT)-$(TIMESTAMP)
 OPENSHIFT_VERSION?=4
-OC_LOGIN_USERNAME?=system:admin
-OC_LOGIN_PASSWORD?=admin
 
 .PHONY: create-resources
 create-resources:

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -11,7 +11,7 @@ REGISTRY_URI=quay.io
 DEVCONSOLE_OPERATOR_IMAGE?=quay.io/redhat-developers/devconsole-operator
 TIMESTAMP:=$(shell date +%s)
 TAG?=$(GIT_COMMIT_ID_SHORT)-$(TIMESTAMP)
-OPENSHIFT_VERSION?=3
+OPENSHIFT_VERSION?=4
 OC_LOGIN_USERNAME?=system:admin
 OC_LOGIN_PASSWORD?=admin
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -98,7 +98,6 @@ ifeq ($(OPENSHIFT_VERSION),3)
 	$(Q)-oc delete catalogsource my-catalog -n olm
 endif
 ifeq ($(OPENSHIFT_VERSION),4)
-	@oc login -u $(OC_LOGIN_USERNAME) -p $(OC_LOGIN_PASSWORD)
 	$(Q)-oc delete subscription my-devconsole -n openshift-operators
 	$(Q)-oc delete catalogsource my-catalog -n openshift-operator-lifecycle-manager
 endif


### PR DESCRIPTION
The OpenShift 4 installer creates a Kubernetes configuration file for authentication.  The `oc` command and Operator SDK clients look for an environment variable named `KUBECONFIG` pointing to this configuration file. https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

* Set OpenShift 4 as the default version as the test target