### PR TITLE
Copy CRD files to operator and registry images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ out/
 coverage.txt
 bin/
 tmp/
+manifests/devconsole/*/*_crd.yaml
 
 # Created by https://www.gitignore.io/api/go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,9 @@
-# TODO: change this to a sane base image
-FROM quay.io/openshiftio/toolchain-operator:faab15e
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+LABEL com.redhat.delivery.appregistry=true
 
-ENV INSTALL_PREFIX=/usr/local/devconsole-operator
+ARG version=0.1.0
 
-COPY bin/devconsole-operator ${INSTALL_PREFIX}/bin/devconsole-operator
-RUN echo chmod +x ${INSTALL_PREFIX}/bin/devconsole-operator
+COPY manifests /manifests
+COPY deploy/crds/*.yaml /manifests/devconsole/${version}/
+COPY build/_output/bin/devconsole-operator /usr/local/bin/devconsole-operator
+USER 10001

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -2,7 +2,9 @@ FROM quay.io/openshift/origin-operator-registry:latest
 
 ARG image=quay.io/redhat-developer/devconsole-operator
 ARG version=0.1.0
+
 COPY manifests manifests
+COPY deploy/crds/*.yaml manifests/devconsole/${version}/
 
 USER root
 RUN sed -e "s,REPLACE_IMAGE,${image}," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,10 @@ clean:
 		-ldflags "-X ${GO_PACKAGE_PATH}/cmd/manager.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/cmd/manager.BuildTime=${BUILD_TIME}" \
 		-o ./out/operator \
 		cmd/manager/main.go
+
+.PHONY: copy-crds
+## Copy CRD files to latest OLM manifests directory
+copy-crds:
+	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
+	$(eval devconsole_version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
+	$(Q)cp ./deploy/crds/*.yaml ./manifests/devconsole/$(devconsole_version)/

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -28,14 +28,11 @@ $(GOLANGCI_LINT_BIN):
 
 .PHONY: courier
 ## Validate manifests using operator-courier
-courier:
+courier: copy-crds
 	$(Q)python3 -m venv ./out/venv3
 	$(Q)./out/venv3/bin/pip install --upgrade setuptools
 	$(Q)./out/venv3/bin/pip install --upgrade pip
 	$(Q)./out/venv3/bin/pip install operator-courier==1.3.0
-	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
-	$(eval devconsole_version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
-	$(Q)cp ./deploy/crds/*.yaml ./manifests/devconsole/$(devconsole_version)/
 	# flatten command is throwing error. suppress it for now
 	@-./out/venv3/bin/operator-courier flatten ./manifests/devconsole ./out/manifests-flat
 	$(Q)./out/venv3/bin/operator-courier verify ./out/manifests-flat

--- a/make/test.mk
+++ b/make/test.mk
@@ -70,7 +70,6 @@ ifeq ($(OPENSHIFT_VERSION),3)
 endif
 	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
 	$(eval devconsole_version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
-	$(Q)cp ./deploy/crds/*.yaml ./manifests/devconsole/$(devconsole_version)/
 	$(Q)docker build -f Dockerfile.registry . -t $(DEVCONSOLE_OPERATOR_REGISTRY_IMAGE):$(devconsole_version)-$(TAG) \
 		--build-arg image=$(DEVCONSOLE_OPERATOR_IMAGE):$(TAG) --build-arg version=$(devconsole_version)
 	@docker login -u $(QUAY_USERNAME) -p $(QUAY_PASSWORD) $(REGISTRY_URI)


### PR DESCRIPTION
* The `copy-crds` Makefile target copies  CRD files from `deploy`
directory to latest OLM manifests directory (used by courier).
    
* Copy CRD files within Dockerfile to run test
    
* Ignore CRD files inside OLM manifests directory

* Add manifests to operator image for productization