### PR TITLE
Update version of github.com/golang/protobuf package to 1.3.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,18 +144,25 @@
   revision = "5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b"
 
 [[projects]]
-  digest = "1:d7cb4458ea8782e6efacd8f4940796ec559c90833509c436f40c4085b98156dd"
+  digest = "1:d7212166c4b7f30a20fb3de70ab7e36564900b2e36360ffd31958b5af8fed025"
   name = "github.com/golang/protobuf"
   packages = [
+    "jsonpb",
     "proto",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
+    "ptypes/struct",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = "NT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
@@ -868,6 +875,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/golang/protobuf/proto",
     "github.com/go-openapi/spec",
     "github.com/openshift/api/apps/v1",
     "github.com/openshift/api/build/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,6 +83,6 @@ required = [
   branch = "master"
   name = "github.com/wadey/gocovmerge"
 
-[[constraint]]
+[[override]]
   name = "github.com/golang/protobuf"
   version = "1.3.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,6 +9,7 @@ required = [
   "k8s.io/kube-openapi/cmd/openapi-gen",
   "k8s.io/gengo/args",
   "sigs.k8s.io/controller-tools/pkg/crd/generator",
+  "github.com/golang/protobuf/proto",
 ]
 
 [[override]]
@@ -81,3 +82,7 @@ required = [
 [[constraint]]
   branch = "master"
   name = "github.com/wadey/gocovmerge"
+
+[[constraint]]
+  name = "github.com/golang/protobuf"
+  version = "1.3.1"


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-565

Updating the `github.com/golang/protobuf` package to version `1.3.1` fixes that problem and the test runs again.