### PR TITLE
Use UBI instead of centos for the deployment image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,13 +77,8 @@ ENV LANG=en_US.utf8
 ENV GOPATH=/tmp/go
 ARG GO_PACKAGE_PATH=github.com/redhat-developer/devconsole-operator
 
-# Create a non-root user and a group with the same name: "devconsole-operator"
-ENV OPERATOR_USER_NAME=devconsole-operator
-RUN useradd --no-create-home -s /bin/bash ${OPERATOR_USER_NAME}
-
 COPY --from=builder ${GOPATH}/src/${GO_PACKAGE_PATH}/out/operator /usr/local/bin/devconsole-operator
 
-# From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
-USER ${OPERATOR_USER_NAME}
+USER 10001
 
 ENTRYPOINT [ "/usr/local/bin/devconsole-operator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,11 @@ RUN make VERBOSE=${VERBOSE} test
 
 #--------------------------------------------------------------------
 
-FROM centos:7 as deploy
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+LABEL com.redhat.delivery.appregistry=true
+
 LABEL maintainer "Devtools <devtools@redhat.com>"
-LABEL author "Konrad Kleine <kkleine@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8
 
 ENV GOPATH=/tmp/go

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -1,6 +1,9 @@
-FROM centos:7 as deploy
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+LABEL com.redhat.delivery.appregistry=true
+
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
+
 ENV LANG=en_US.utf8
 
 COPY operator /usr/local/bin/devconsole-operator


### PR DESCRIPTION
- Fix the root Dockerfile to match the openshift-ci/Dockerfile.deploy to use an arbitrary user
- Replace base image with a UBI image. 