### PR TITLE
remove obsolete Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.8
-
-RUN apk upgrade --update --no-cache
-
-USER nobody
-
-ADD build/_output/bin/devconsole-operator /usr/local/bin/devconsole-operator


### PR DESCRIPTION
This PR removes auto generated Dockerfile by operator-sdk which is obsolete 