### PR TITLE
add symbolic link build/Dockerfile -> Dockerfile.dev

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,1 @@
+../Dockerfile.dev


### PR DESCRIPTION
Currently, operator-sdk expects Dockerfile under `build/Dockerfile` for `operator-sdk run local` and `operator-sdk build`. There is no way of adding custom command line flag for Dockerfile location.

We are keeping `Dockerfile.dev` under root of project for easy navigation. This is why just creating symbolink link from build directory like `ln -s ../Dockerfile.dev ./Dockerfile`, this way we are good for any expectation from operator-sdk 