### PR TITLE
add reason parameter to both GitSource and GitSourceAnalysis CRDs

### DIFF
--- a/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
@@ -89,6 +89,7 @@ spec:
                 reason:
                   description: Reason is a short predefined string representing
                     a reason for the connection failure
+                    Possible values are [RepoNotReachable, BranchNotFound, BadCredentials, InternalFailure]
                   type: string
               required:
                 - state

--- a/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
@@ -86,6 +86,10 @@ spec:
                   description: Error has the error message if the attempt to
                     reach a GitSource failed
                   type: string
+                reason:
+                  description: Reason is a short predefined string representing
+                    a reason for the connection failure
+                  type: string
               required:
                 - state
   version: v1alpha1

--- a/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
@@ -77,7 +77,8 @@ spec:
               type: string
             reason:
               description: Reason is a short predefined string representing
-                a reason for the build type detection failure
+                a reason for the build type detection failure.
+                Possible values are [NotSupportedType, DetectionFailed, InternalFailure]
               type: string
   version: v1alpha1
   versions:

--- a/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
@@ -75,6 +75,10 @@ spec:
             error:
               description: Error contains an error message in case the build environment detection fails. Optional
               type: string
+            reason:
+              description: Reason is a short predefined string representing
+                a reason for the build type detection failure
+              type: string
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/examples/status/analyzed_gitsourceanalysis_cr.yaml
+++ b/examples/status/analyzed_gitsourceanalysis_cr.yaml
@@ -1,0 +1,23 @@
+#
+# example where repository is successfully analyzed
+#
+apiVersion: devconsole.openshift.io/v1alpha1
+kind: GitSourceAnalysis
+metadata:
+  name: example-gitsource-analysis
+spec:
+  spec:
+    gitSourceRef:
+      name: example-gitsource
+status:
+  analyzed: true
+  buildEnvStatistics:
+    detectedBuildTypes:
+      detectedFiles:
+        Gopkg.toml
+      language: go
+      name: Golang
+    sortedLanguages:
+      Go
+      Makefile
+      Dockerfile

--- a/examples/status/bad_credentials_gitsource_cr.yaml
+++ b/examples/status/bad_credentials_gitsource_cr.yaml
@@ -1,6 +1,5 @@
 #
-# example where repository is reachable (is public)
-# but the name of the branch cannot be found
+# example where the given secret is wrong
 #
 apiVersion: devconsole.openshift.io/v1alpha1
 kind: GitSource
@@ -12,7 +11,7 @@ spec:
   flavor: github
 status:
   connection:
-    error: unable to find the branch
-    reason: BranchNotFound
+    error: cannot get user information
+    reason: BadCredentials
     state: failed
   state: initializing

--- a/examples/status/detection_failed_gitsourceanalysis_cr.yaml
+++ b/examples/status/detection_failed_gitsourceanalysis_cr.yaml
@@ -1,0 +1,15 @@
+#
+# example where the detection failed
+#
+apiVersion: devconsole.openshift.io/v1alpha1
+kind: GitSourceAnalysis
+metadata:
+  name: example-gitsource-analysis
+spec:
+  spec:
+    gitSourceRef:
+      name: example-gitsource
+status:
+  analyzed: true
+  error: failed while getting list of languages
+  reason: DetectionFailed

--- a/examples/status/internal_error_gitsource_cr.yaml
+++ b/examples/status/internal_error_gitsource_cr.yaml
@@ -1,6 +1,5 @@
 #
-# example where repository is reachable (is public)
-# but the name of the branch cannot be found
+# example with internal error while fetching secret object
 #
 apiVersion: devconsole.openshift.io/v1alpha1
 kind: GitSource
@@ -12,7 +11,7 @@ spec:
   flavor: github
 status:
   connection:
-    error: unable to find the branch
-    reason: BranchNotFound
+    error: failed to fetch the secret object
+    reason: InternalFailure
     state: failed
   state: initializing

--- a/examples/status/internal_failure_gitsourceanalysis_cr.yaml
+++ b/examples/status/internal_failure_gitsourceanalysis_cr.yaml
@@ -1,0 +1,15 @@
+#
+# example with internal error while fetching secret object
+#
+apiVersion: devconsole.openshift.io/v1alpha1
+kind: GitSourceAnalysis
+metadata:
+  name: example-gitsource-analysis
+spec:
+  spec:
+    gitSourceRef:
+      name: example-gitsource
+status:
+  analyzed: true
+  error: failed to fetch the secret object
+  reason: InternalFailure

--- a/examples/status/not_supported_type_gitsourceanalysis_cr.yaml
+++ b/examples/status/not_supported_type_gitsourceanalysis_cr.yaml
@@ -1,0 +1,15 @@
+#
+# example when no git implementation was found
+#
+apiVersion: devconsole.openshift.io/v1alpha1
+kind: GitSourceAnalysis
+metadata:
+  name: example-gitsource-analysis
+spec:
+  spec:
+    gitSourceRef:
+      name: example-gitsource
+status:
+  analyzed: true
+  error: no git implementation found
+  reason: NotSupportedType

--- a/examples/status/unreachable_gitsource_cr.yaml
+++ b/examples/status/unreachable_gitsource_cr.yaml
@@ -12,5 +12,6 @@ spec:
 status:
   connection:
     error: unable to reach the URL
+    reason: RepoNotReachable
     state: failed
   state: initializing


### PR DESCRIPTION
Add short reason parameter to both GitSource and GitSourceAnalysis CRDs that can be easily checked by UI (or another client) - represents the reason for the failure.
For more information on possible failure combinations see this doc: https://docs.google.com/spreadsheets/d/1Qn2cioIXj8r3bcVddzISUZiJ2ODq6hWFg6TI_fIz34U/edit#gid=0
added also a few examples

related PR: https://github.com/redhat-developer/devconsole-api/pull/20