### PR TITLE
Exposed ports

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -305,7 +305,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f2001f00154e95650b38a99443ae686d1b22903e9263958079f2f2dbabe5c43c"
+  digest = "1:f620c969301c9543b5a311a662615f69fbaeeb6864865df9e86a3eca560445e6"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -317,7 +317,7 @@
     "pagination",
   ]
   pruneopts = "NT"
-  revision = "1d93848c29c42ba3ebb1dbdff7a192a70d112003"
+  revision = "bb98932a7b3a106e1814e0c6b7f7d48c0a71a919"
 
 [[projects]]
   branch = "master"
@@ -446,7 +446,8 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:8bc8f43d2332d035857c92581df240f247c287629d5f60c751df609f9b6215c5"
+  branch = "rebase-1.13.4"
+  digest = "1:65f27352945521c648be4070c006062a990fd6987d536cdc275002f698e12f32"
   name = "github.com/openshift/api"
   packages = [
     "apps/v1",
@@ -457,8 +458,21 @@
     "route/v1",
   ]
   pruneopts = "NT"
-  revision = "0d921e363e951d89f583292c60d013c318df64dc"
-  version = "v3.9.0"
+  revision = "3a6077f1f910bfaec1f34ae9db3492a52e804ae0"
+
+[[projects]]
+  branch = "rebase-1.13.4"
+  digest = "1:a5aa6d074656d7cd97b9e1744f2c79244b8bc37ffb67cb31c47298010092c881"
+  name = "github.com/openshift/client-go"
+  packages = [
+    "image/clientset/versioned",
+    "image/clientset/versioned/fake",
+    "image/clientset/versioned/scheme",
+    "image/clientset/versioned/typed/image/v1",
+    "image/clientset/versioned/typed/image/v1/fake",
+  ]
+  pruneopts = "NT"
+  revision = "84c2b942258aea2462e675e03aeb8eb4cb5f3c29"
 
 [[projects]]
   digest = "1:674610d54812d3c36ab7861fc826176bf581a9426cc09abec0107414c17f89cd"
@@ -1015,6 +1029,7 @@
   packages = [
     "discovery",
     "discovery/cached",
+    "discovery/fake",
     "dynamic",
     "kubernetes",
     "kubernetes/scheme",
@@ -1255,8 +1270,11 @@
     "github.com/golang/protobuf/proto",
     "github.com/openshift/api/apps/v1",
     "github.com/openshift/api/build/v1",
+    "github.com/openshift/api/image/docker10",
     "github.com/openshift/api/image/v1",
     "github.com/openshift/api/route/v1",
+    "github.com/openshift/client-go/image/clientset/versioned/fake",
+    "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/ready",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,6 +63,14 @@ required = [
   # branch = "master" #osdk_branch_annotation
   version = "=v0.7.0" #osdk_version_annotation
 
+[[constraint]]
+  name = "github.com/openshift/client-go"
+  branch = "rebase-1.13.4"
+
+[[constraint]]
+  name = "github.com/openshift/api"
+  branch = "rebase-1.13.4"
+
 [prune]
   go-tests = true
   non-go = true

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/openshift/api/image/docker10"
 	"os"
 	"runtime"
 
@@ -108,6 +109,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	if err := docker10.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -32,6 +32,7 @@ rules:
   - image.openshift.io
   resources:
   - imagestreams
+  - imagestreamimages
   verbs:
   - create
   - get

--- a/examples/devconsole_v1alpha1_gitsource_cr.yaml
+++ b/examples/devconsole_v1alpha1_gitsource_cr.yaml
@@ -9,6 +9,4 @@ spec:
   httpProxy: http://proxy.example.com
   httpsProxy: https://proxy.example.com
   noProxy: somedomain.com, otherdomain.com
-  secretRef:
-    name: mysecret
   flavor: github

--- a/pkg/controller/component/component_resources.go
+++ b/pkg/controller/component/component_resources.go
@@ -102,8 +102,14 @@ func newBuildConfig(cr *devconsoleapi.Component, builder *imagev1.ImageStream, g
 	}
 }
 
-func newDeploymentConfig(cr *devconsoleapi.Component, output *imagev1.ImageStream) *v1.DeploymentConfig {
+func newDeploymentConfig(cr *devconsoleapi.Component, output *imagev1.ImageStream, containerPorts []corev1.ContainerPort) *v1.DeploymentConfig {
 	labels := resource.GetLabelsForCR(cr)
+	if containerPorts == nil {
+		containerPorts = []corev1.ContainerPort{{
+			ContainerPort: 8080,
+			Protocol:      corev1.ProtocolTCP,
+		}}
+	}
 	return &v1.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -126,11 +132,7 @@ func newDeploymentConfig(cr *devconsoleapi.Component, output *imagev1.ImageStrea
 					Containers: []corev1.Container{{
 						Name:  output.Name,
 						Image: output.Name + ":latest",
-						Ports: []corev1.ContainerPort{{ // do we plan to have several ports exposed?
-							ContainerPort: 8080,
-							Protocol:      corev1.ProtocolTCP,
-						},
-						},
+						Ports: containerPorts,
 					},
 					},
 				},

--- a/pkg/controller/component/utils.go
+++ b/pkg/controller/component/utils.go
@@ -1,0 +1,78 @@
+package component
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/openshift/api/image/docker10"
+	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+	"strconv"
+	"strings"
+)
+
+// getExposedPortsFromISI parse ImageStreamImage definition and return all exposed ports in form of ContainerPorts structs
+// borrowed from https://github.com/openshift/odo/blob/2b98a06e811a60a08c9a6545c9698896d91e8f0b/pkg/occlient/occlient.go#L541
+func getExposedPortsFromImageStreamImage(image *imagev1.ImageStreamImage) ([]corev1.ContainerPort, error) {
+	// file DockerImageMetadata
+	if err := imageWithMetadata(&image.Image); err != nil {
+		return nil, err
+	}
+	var ports []corev1.ContainerPort
+	for exposedPort := range image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).ContainerConfig.ExposedPorts {
+		splits := strings.Split(exposedPort, "/")
+		if len(splits) != 2 {
+			return nil, fmt.Errorf("invalid port %s", exposedPort)
+		}
+
+		portNumberI64, err := strconv.ParseInt(splits[0], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		portNumber := int32(portNumberI64)
+
+		var portProto corev1.Protocol
+		switch strings.ToUpper(splits[1]) {
+		case "TCP":
+			portProto = corev1.ProtocolTCP
+		case "UDP":
+			portProto = corev1.ProtocolUDP
+		default:
+			return nil, fmt.Errorf("invalid port protocol %s", splits[1])
+		}
+		port := corev1.ContainerPort{
+			Name:          fmt.Sprintf("%d-%s", portNumber, strings.ToLower(string(portProto))),
+			ContainerPort: portNumber,
+			Protocol:      portProto,
+		}
+		ports = append(ports, port)
+	}
+	return ports, nil
+}
+
+// imageWithMetadata mutates the given image. It parses raw DockerImageManifest data stored in the image and
+// fills its DockerImageMetadata and other fields.
+// Copied from v3.7 github.com/openshift/origin/pkg/image/apis/image/v1/helpers.go
+func imageWithMetadata(image *imagev1.Image) error {
+	// Check if the metadata are already filled in for this image.
+	meta, hasMetadata := image.DockerImageMetadata.Object.(*docker10.DockerImage)
+	if hasMetadata && meta.Size > 0 {
+		return nil
+	}
+
+	version := image.DockerImageMetadataVersion
+	if len(version) == 0 {
+		version = "1.0"
+	}
+
+	obj := &docker10.DockerImage{}
+	if len(image.DockerImageMetadata.Raw) != 0 {
+		if err := json.Unmarshal(image.DockerImageMetadata.Raw, obj); err != nil {
+			return err
+		}
+		image.DockerImageMetadata.Object = obj
+	}
+
+	image.DockerImageMetadataVersion = version
+
+	return nil
+}


### PR DESCRIPTION
Fixes odc-515
This PR makes sure the default port is not hard coded to 8080 but is extracted from S2I builder image.
- If the port is provided in Component's spec port, this port is used instead of the S2I exposed port.
- if no port is provided in Component's spec port, port is extracted from S2I builder image.