### PR TITLE
add short names for gitsource and gitsourceanalysis

### DIFF
--- a/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
@@ -9,6 +9,8 @@ spec:
     listKind: GitSourceList
     plural: gitsources
     singular: gitsource
+    shortNames:
+      - src
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -93,6 +95,10 @@ spec:
                   type: string
               required:
                 - state
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.state
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsource_crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: gitsources
     singular: gitsource
     shortNames:
-      - src
+      - gs
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: gitsourceanalyses
     singular: gitsourceanalysis
     shortNames:
-      - srcan
+      - gsa
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
+++ b/deploy/crds/devconsole_v1alpha1_gitsourceanalysis_crd.yaml
@@ -9,6 +9,8 @@ spec:
     listKind: GitSourceAnalysisList
     plural: gitsourceanalyses
     singular: gitsourceanalysis
+    shortNames:
+      - srcan
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -80,6 +82,10 @@ spec:
                 a reason for the build type detection failure.
                 Possible values are [NotSupportedType, DetectionFailed, InternalFailure]
               type: string
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.analyzed
   version: v1alpha1
   versions:
     - name: v1alpha1


### PR DESCRIPTION
@MatousJobanek so we can have sth shorter like:
```
➜  oc get all,dc,svc,dc,bc,route,cp,src,srcan
NAME                READY     STATUS      RESTARTS   AGE
pod/myapp-1-6lgmq   1/1       Running     0          5m
pod/myapp-1-build   0/1       Completed   0          6m

NAME                            DESIRED   CURRENT   READY     AGE
replicationcontroller/myapp-1   1         1         1         5m

NAME            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/myapp   ClusterIP   172.30.220.21   <none>        8080/TCP   6m

NAME                                       REVISION   DESIRED   CURRENT   TRIGGERED BY
deploymentconfig.apps.openshift.io/myapp   1          1         1         config,image(myapp:latest)

NAME                                   TYPE      FROM         LATEST
buildconfig.build.openshift.io/myapp   Source    Git@master   1

NAME                               TYPE      FROM          STATUS     STARTED         DURATION
build.build.openshift.io/myapp-1   Source    Git@e59fe75   Complete   6 minutes ago   1m6s

NAME                                   DOCKER REPO                        TAGS      UPDATED
imagestream.image.openshift.io/myapp   172.30.1.1:5000/local-test/myapp   latest    5 minutes ago

NAME                             HOST/PORT                                PATH      SERVICES   PORT      TERMINATION   WILDCARD
route.route.openshift.io/myapp   myapp-local-test.192.168.99.100.nip.io             myapp      8080                    None

NAME                                      STATUS
component.devconsole.openshift.io/myapp   Deployed

NAME                                                  STATUS
gitsource.devconsole.openshift.io/example-gitsource

NAME                                                                   STATUS
gitsourceanalysis.devconsole.openshift.io/example-gitsource-analysis   true
```