### PR TITLE
Extend E2E test to include coverage for creating Operator from OperatorSource

### DIFF
--- a/test/e2e/catalog_source_opsrc.yaml
+++ b/test/e2e/catalog_source_opsrc.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: installed-upstream-community-operators
+  namespace: openshift-marketplace
+spec:
+  targetNamespace: openshift-operator-lifecycle-manager
+  packages: devconsole
+  csDisplayName: "Upstream Community Operators"
+  csPublisher: "Red Hat"

--- a/test/e2e/devconsole.operatorsource.yaml
+++ b/test/e2e/devconsole.operatorsource.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata: 
+  name: devconsole-operators
+  namespace: openshift-marketplace
+spec: 
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: REPLACE_NAMESPACE
+  displayName: "Red Hat Devconsole Operator"
+  publisher: "Red Hat"

--- a/test/e2e/subscription_opsrc.yaml
+++ b/test/e2e/subscription_opsrc.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: devconsole
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  channel: alpha
+  name: devconsole
+  source: installed-upstream-community-operators
+  sourceNamespace: openshift-operator-lifecycle-manager
+


### PR DESCRIPTION
This pull request will include:
* OperatorSource definition file extend E2E test to include verifying creating Operator from OperatorSource as defined here: https://github.com/operator-framework/operator-marketplace
* Updates to the E2E test

Ref: https://jira.coreos.com/browse/ODC-580