### PR TITLE
Register gitsourceanalysis to deploy-test target

### DIFF
--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -45,6 +45,7 @@ deploy-test:
 	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE)
 	$(Q)-oc apply -f examples/devconsole_v1alpha1_gitsource_cr.yaml
 	$(Q)-oc apply -f examples/devconsole_v1alpha1_component_cr.yaml
+	$(Q)-oc apply -f examples/devconsole_v1alpha1_gitsourceanalysis_cr.yaml
 
 endif
 


### PR DESCRIPTION
`make deploy-test` should deploy component, gitsource and gitsourceanalysis cr. But I saw gitsourceanalysis was missing so this PR is to add it to deploy-test target.

Steps to test:
`make clean`
`make build`
`make local`
after seeing some msg like: `{"level":"info","ts":1556020410.5623667,"msg":"🎉🎉  Component myapp has been successfully created!  🎉🎉 "}` 
in new terminal window run `make deploy-clean` and then `make deploy-test`
and final step is to run `oc get gs, gsa` 
you should see something like this
```
NAME                                                  STATUS
gitsource.devconsole.openshift.io/example-gitsource   

NAME                                                                   STATUS
gitsourceanalysis.devconsole.openshift.io/example-gitsource-analysis   true

```