### PR TITLE
Skip resource creation with --no-setup option

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -72,7 +72,7 @@ ifeq ($(OPENSHIFT_VERSION),4)
 	$(Q)sed -e "s,REPLACE_IMAGE,$(DEVCONSOLE_OPERATOR_REGISTRY_IMAGE):$(devconsole_version)-$(TAG)," ./test/e2e/catalog_source_OS4.yaml | oc apply -f -
 	$(Q)oc apply -f ./test/e2e/subscription_OS4.yaml
 endif
-	$(Q)operator-sdk test local ./test/e2e/ --go-test-flags "-v -parallel=1 -timeout=15m"
+	$(Q)operator-sdk test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout=15m"
 
 .PHONY: olm-integration-setup
 olm-integration-setup: olm-integration-cleanup


### PR DESCRIPTION
- OML must be creating the necessary resources
- Remove parallel option as it is already provided by the SDK cli