### PR TITLE
Add a base image which openshift can overwrite

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -1,3 +1,4 @@
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
 FROM quay.io/openshift/origin-operator-registry:latest
 
 ARG image=quay.io/redhat-developer/devconsole-operator


### PR DESCRIPTION
If we were to use https://github.com/openshift/release/pull/3610/files for building the registry, we need to accommodate the fact that the `FROM` in the first line is going to be overwritten by the base image specified in the ci config.

@baijum , there might be a better way to do this :)

That would avoid the following error

https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/3610/rehearse-3610-pull-ci-redhat-developer-devconsole-operator-master-images/2/build-log.txt

```
2019/04/26 14:09:35 Build devconsole-operator-registry failed, printing logs:
Pulling image "docker-registry.default.svc:5000/ci-op-y5zd239b/pipeline@sha256:017d67bea2925ba8c9d644b066b4e306330e8632416375bbf4f4a9db79d90f76" ...
Replaced Dockerfile FROM image quay.io/openshift/origin-operator-registry:latest

Pulling image docker-registry.default.svc:5000/ci-op-y5zd239b/pipeline@sha256:ca58fe458b8d94bc6e3072f1cfbd334855858e05e1fd633aa07cf7f82b048e66 ...
--> FROM docker-registry.default.svc:5000/ci-op-y5zd239b/pipeline@sha256:ca58fe458b8d94bc6e3072f1cfbd334855858e05e1fd633aa07cf7f82b048e66 as 0
--> ARG image=quay.io/redhat-developer/devconsole-operator
--> ARG version=0.1.0
--> COPY manifests manifests
--> COPY deploy/crds/*.yaml manifests/devconsole/${version}/
--> USER root
--> RUN sed -e "s,REPLACE_IMAGE,${image}," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
--> USER 1001
--> RUN initializer
/bin/sh: initializer: command not found
error: build error: running 'initializer' failed with exit code 127
2019/04/26 14:16:38 Build bin succeeded after 10m50s
2019/04/26 14:16:39 Building devconsole-operator
2019/04/26 14:21:27 Build devconsole-operator succeeded after 4m46s
2019/04/26 14:21:27 Tagging devconsole-operator into stable
2019/04/26 14:21:28 Ran for 21m23s
error: could not run steps: step devconsole-operator-registry failed: could not wait for build: the build devconsole-operator-registry failed after 3m48s with reason DockerBuildFailed: Docker build strategy has failed.

--> RUN sed -e "s,REPLACE_IMAGE,${image}," -i manifests/de.../devconsole-operator.v${version}.clusterserviceversion.yaml
--> USER 1001
--> RUN initializer
/bin/sh: initializer: command not found
error: build error: running 'initializer' failed with exit code 127
```