### PR TITLE
Use /usr/local/bin for registry

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -54,10 +54,10 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && make dep \
     && make install
 
-COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/initializer /bin/initializer
-COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/registry-server /bin/registry-server
-COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/configmap-server /bin/configmap-server
-COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/appregistry-server /bin/appregistry-server
+COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/initializer /usr/local/bin/initializer
+COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/registry-server /usr/local/bin/registry-server
+COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/configmap-server /usr/local/bin/configmap-server
+COPY --from=quay.io/openshift/origin-operator-registry:latest /bin/appregistry-server /usr/local/bin/appregistry-server
 
 RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
 


### PR DESCRIPTION
The base image is needed for building the operator-registry.

For some reason the binary goes missing ( In subsequent images layers) after putting it in /bin which is not unexpected since user programs are not too be kept in /bin .