### PR TITLE
chore(ODC-64): update devconsole-git to bring credentials validation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -651,8 +651,7 @@
   revision = "e9de16b0f6bbc760546eb19e3cec6e043855f8fa"
 
 [[projects]]
-  branch = "master"
-  digest = "1:38cd7170ec1cf3b851012b9c71a0e42543b0983b06604929829c1ab6b8fb98de"
+  digest = "1:f0988454715cc92c944f7c82089ea62de7b89e33a26233ea5acd3ef27a90989d"
   name = "github.com/redhat-developer/devconsole-git"
   packages = [
     "pkg/controller/gitsource",
@@ -669,7 +668,7 @@
     "pkg/log",
   ]
   pruneopts = "NT"
-  revision = "e6043276a7e959284edfd7840c3d20fe84c02576"
+  revision = "b5ac7c18ca5de088b4b00c7220c0f97896b4400a"
 
 [[projects]]
   digest = "1:a4644e85e1f29f9825a4e61dcdd8244fe7c4db02eead3f508d5a5bdf7924dbbd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -98,7 +98,7 @@ required = [
 
 [[constraint]]
   name = "github.com/redhat-developer/devconsole-git"
-  revision = "e6043276a7e959284edfd7840c3d20fe84c02576"
+  revision = "b5ac7c18ca5de088b4b00c7220c0f97896b4400a"
 
 [[constraint]]
   name = "github.com/redhat-developer/devconsole-api"


### PR DESCRIPTION
update devconsole-git to use https://github.com/redhat-developer/devconsole-git/commit/b5ac7c18ca5de088b4b00c7220c0f97896b4400a