### PR TITLE
Use the base image available in the OpenShift CI

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,12 +1,11 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
-ARG image=registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator
 ARG version=0.1.0
 
 COPY manifests manifests
 COPY deploy/crds/*.yaml manifests/devconsole/${version}/
 
-RUN sed -e "s,REPLACE_IMAGE,${image}," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
+RUN sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
 RUN initializer
 
 USER 1001

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,24 +1,14 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
+ARG image=registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator
 ARG version=0.1.0
 
 COPY manifests manifests
 COPY deploy/crds/*.yaml manifests/devconsole/${version}/
-RUN curl -L -s https://github.com/devconsole-operator-test-deps/operator-registry-binaries/releases/download/v0.1.0/appregistry-server -o /bin/appregistry-server \
-  && chmod +x /bin/appregistry-server
-RUN curl -L -s https://github.com/devconsole-operator-test-deps/operator-registry-binaries/releases/download/v0.1.0/configmap-server -o /bin/configmap-server \
-  && chmod +x /bin/configmap-server
-RUN curl -L -s https://github.com/devconsole-operator-test-deps/operator-registry-binaries/releases/download/v0.1.0/registry-server -o /bin/registry-server \
-  && chmod +x /bin/registry-server
-RUN curl -L -s https://github.com/devconsole-operator-test-deps/operator-registry-binaries/releases/download/v0.1.0/initializer -o /bin/initializer \
-  && chmod +x /bin/initializer
-RUN curl -L -s https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.2.2/grpc_health_probe-linux-amd64 -o /bin/grpc_health_probe \
-  && chmod +x /bin/grpc_health_probe
 
-RUN sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
-
+RUN sed -e "s,REPLACE_IMAGE,${image}," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
 RUN initializer
-USER 1001
 
+USER 1001
 EXPOSE 50051
 CMD ["registry-server"]


### PR DESCRIPTION
This confuration should work with any operator registry location.
The location is provided as an arument with default value pointing to
OpenShift CI.