### PR TITLE
[WIP] Create Makefile target to build & bundle CSV file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ include ./make/docker.mk
 ## Build the operator
 build: ./out/operator
 
+.PHONY: ci-build
+ci-build: build
+	$(eval package_yaml := ./manifests/devconsole/devconsole.package.yaml)
+	$(eval version := $(shell cat $(package_yaml) | grep "currentCSV"| cut -d "." -f2- | cut -d "v" -f2 | tr -d '[:space:]'))
+	$(Q)sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator," \
+		-i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
+	$(Q)tar -zcvf ./out/csv.tar.gz manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
+
 .PHONY: clean
 clean:
 	$(Q)-rm -rf ${V_FLAG} ./out

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -4,8 +4,8 @@ ARG version=0.1.0
 
 COPY manifests manifests
 COPY deploy/crds/*.yaml manifests/devconsole/${version}/
+ADD csv.tar.gz .
 
-RUN sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:devconsole-operator," -i manifests/devconsole/${version}/devconsole-operator.v${version}.clusterserviceversion.yaml
 RUN initializer
 
 USER 1001


### PR DESCRIPTION
The CI configuration will be updated to receive this:

```
- from: operator-registry
  inputs:
    bin:
      paths:
      - destination_dir: .
        source_path: /go/src/github.com/redhat-developer/devconsole-operator/out/csv.tar.gz
  dockerfile_path: openshift-ci/Dockerfile.registry.build
  to: devconsole-operator-registry
```

The `bin` build will be modified like this:
```
binary_build_commands: make ci-build
```