### PR TITLE
Increase time to wait for pulling registry image

### DIFF
--- a/hack/check-crds.sh
+++ b/hack/check-crds.sh
@@ -9,7 +9,7 @@ function check_crds() {
 			echo "CRD exists: " $crd_name
 			return 0
 		fi
-		sleep 5s
+		sleep 10s
 	done
 	echo "CRD doesn't exist: " $crd_name
 	exit 1


### PR DESCRIPTION
Sometimes OLM integration test is failing as the CRDs are not created.
This happens as the registry image is 370+ MB and pulling that image takes time.