### PR TITLE
Switch to the install_devconsole directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ coverage.txt
 bin/
 tmp/
 manifests/devconsole/*/*_crd.yaml
+hack/install_devconsole/htpass
 
 # Created by https://www.gitignore.io/api/go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode

--- a/hack/install_devconsole/consoledeveloper.sh
+++ b/hack/install_devconsole/consoledeveloper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set +x
 
-cd $(dirname $(readlink -f $(which $0)))
+cd $(dirname $(readlink -f $0))
 
 oc apply -f ./yamls/unmanage.yaml
 oc scale --replicas 0 deployment console-operator --namespace openshift-console-operator

--- a/hack/install_devconsole/consoledeveloper.sh
+++ b/hack/install_devconsole/consoledeveloper.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set +x
 
+cd $(dirname $(readlink -f $(which $0)))
+
 oc apply -f ./yamls/unmanage.yaml
 oc scale --replicas 0 deployment console-operator --namespace openshift-console-operator
 oc scale --replicas 0 deployment console --namespace openshift-console


### PR DESCRIPTION
This PR improves the `hack/install_devconsole/` scripts:
* Changes the working directory for the `hack/install_devconsole/consoledeveloper.sh` script to it's directory so that the script can be executed from anywhere
* Adds generated `hact/install_devconsole/htpass` file to `.gitignore`