### PR TITLE
Add chromedriver to the tools images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN yum install epel-release -y \
     kubectl \
     yamllint \
     python36-virtualenv \
+    chromium-headless \
+    chromedriver \
     && yum clean all
 
 # install dep

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -22,6 +22,8 @@ RUN yum install epel-release -y \
     kubectl \
     yamllint \
     python36-virtualenv \
+    chromium-headless \
+    chromedriver \
     && yum clean all
 
 # install dep


### PR DESCRIPTION
This PR installs `chromium-headless` and `chromedriver` packages from `epel-release` to the `root` image.
These are the dependencies needed to run the UI tests (#206) on CI.