### PR TITLE
Add missing chromium package to the tools images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN yum install epel-release -y \
     kubectl \
     yamllint \
     python36-virtualenv \
+    chromium \
     chromium-headless \
     chromedriver \
     && yum clean all

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -22,6 +22,7 @@ RUN yum install epel-release -y \
     kubectl \
     yamllint \
     python36-virtualenv \
+    chromium \
     chromium-headless \
     chromedriver \
     && yum clean all


### PR DESCRIPTION
This PR installs missing `chromium` package to the `root` image.
This is a dependency needed to run the UI tests (#206) on CI.