### PR TITLE
Install htpasswd to the tools images for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN yum install epel-release -y \
     chromium \
     chromium-headless \
     chromedriver \
+    httpd-tools \
     && yum clean all
 
 # install dep

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -25,6 +25,7 @@ RUN yum install epel-release -y \
     chromium \
     chromium-headless \
     chromedriver \
+    httpd-tools \
     && yum clean all
 
 # install dep


### PR DESCRIPTION
This PR installs `htpasswd` tool (via `httpd-tools` package) to the tools image for CI.